### PR TITLE
Workaround for bug occuring when having spaces in path

### DIFF
--- a/Java.crLanguage/Scripts/compile.sh
+++ b/Java.crLanguage/Scripts/compile.sh
@@ -33,9 +33,13 @@ enc[1]="ASCII"			# ASCII
 
 directory=`dirname "$0"`
 
+originalWorkingDirectory="$PWD"
+cp "$PWD/$CR_FILENAME" "$CR_TMPDIR/$CR_FILENAME"
+cd "$CR_TMPDIR"
+
 # Check if file resides in a folder with package name, if so, change directory
 package=`"$CR_DEVELOPER_DIR/bin/parsejava" --package "$PWD/$CR_FILENAME" 2>/dev/null`
-if [ ${#package} -ne 0 ]; then
+if [ $? -eq 0 ] && [ ${#package} -ne 0 ]; then
 	# Check if package name is in the form package.subpackage.subpackage
 	# If this structure matches directory structure, change directory...
 	packageDirectory=`echo "$package" | sed 's/\./\//g'`
@@ -61,17 +65,6 @@ elif [ ! -z $CR_SANDBOXED ] && [ ! -r "$PWD" ]; then
 	cd "$tmp"
 fi
 
-javac "$CR_FILENAME" -encoding ${enc[$CR_ENCODING]} "${@:1}" ${CR_DEBUGGING:+-g}
-status=$?
-
-if [ $status -ne 0 ]; then
-	javac -version &>/dev/null
-	if [ $? -ne 0 ]; then
-		echo -e "\nTo run Java code, you need to install a JDK. You can download a JDK at http://oracle.com/technetwork/java/javase/downloads/\n\nIf you see a prompt asking you to install Java, it may not include the necessary components for compiling Java code. Therefore, use the link above to download and install a JDK."
-	fi
-	exit $status
-fi
-
 # Use parsejava to get package and class name of main function.
 out=`"$CR_DEVELOPER_DIR/bin/parsejava" "$PWD/$CR_FILENAME" 2>/dev/null`
 status=$?
@@ -83,6 +76,19 @@ if [ $status -ne 0 ]; then
 	else
 		out="$out.$compname"
 	fi
+fi
+
+cd "$originalWorkingDirectory";
+
+javac "$CR_FILENAME" -encoding ${enc[$CR_ENCODING]} "${@:1}" ${CR_DEBUGGING:+-g}
+status=$?
+
+if [ $status -ne 0 ]; then
+	javac -version &>/dev/null
+	if [ $? -ne 0 ]; then
+		echo -e "\nTo run Java code, you need to install a JDK. You can download a JDK at http://oracle.com/technetwork/java/javase/downloads/\n\nIf you see a prompt asking you to install Java, it may not include the necessary components for compiling Java code. Therefore, use the link above to download and install a JDK."
+	fi
+	exit $status
 fi
 
 echo "$PWD:$out"


### PR DESCRIPTION
When having spaces somewhere in the path to the current working directory or the file that's going to be compiled, parsejava (/Applications/CodeRunner.app/Contents/SharedSupport/Developer/bin/parsejava) can't deal with that and says "The file “xyz.java” couldn’t be opened because there is no such file."